### PR TITLE
update sed regex to delete Ignore annotation with or without optional message

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -15,7 +15,7 @@ compiler_error_log="compiler.log"
 cp -r $input_folder /opt/test-runner/lib/$problem_slug
 cd /opt/test-runner/lib
 
-find . -mindepth 1 -type f | grep 'Test.java' | xargs -I file sed -i "s/@Ignore/\n/g" file
+find . -mindepth 1 -type f | grep 'Test.java' | xargs -I file sed -i "s/@Ignore(.*)//g;s/@Ignore//g;" file
 cat <<EOF >settings.gradle
 include '${problem_slug}'
 EOF


### PR DESCRIPTION
Closes #18 .

The issue was that the expected Ignore statement was `@Ignore` but in this test case, the ignore annotation was also given a message like `@Ignore("Some message")`

This PR allows the java test runner to handle both these scenarios.