### PR TITLE
Switch to Maven on infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .settings
 **/bin/
 **/build/
+target
 
 results.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,21 @@ COPY lib/src ./src
 COPY lib/build.gradle ./
 
 # Build test runner
+RUN echo "no-cache"
 RUN gradle -i clean build
 RUN gradle -i shadowJar \
     && cp build/libs/autotest-runner.jar .
 
+FROM maven:3.8.3-jdk-11 AS cache
+
 # Ensure exercise dependencies are downloaded
 WORKDIR /opt/exercise
 COPY exercise .
-RUN gradle build
+RUN mvn test dependency:go-offline -DexcludeReactor=false
 
 # === Build runtime image ===
 
-FROM gradle:6.8.3-jdk11
+FROM maven:3.8.3-jdk-11
 WORKDIR /opt/test-runner
 
 # Copy binary and launcher script
@@ -28,6 +31,9 @@ COPY bin/ ./bin/
 COPY --from=build /home/builder/autotest-runner.jar ./
 
 # Copy cached dependencies
-COPY --from=build /home/gradle /home/gradle
+COPY --from=cache /root/.m2 /root/.m2
+
+# Copy Maven pom.xml
+COPY --from=cache /opt/exercise/pom.xml /home/pom.xml
 
 ENTRYPOINT ["sh", "/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY lib/src ./src
 COPY lib/build.gradle ./
 
 # Build test runner
-RUN echo "no-cache"
 RUN gradle -i clean build
 RUN gradle -i shadowJar \
     && cp build/libs/autotest-runner.jar .
@@ -34,6 +33,6 @@ COPY --from=build /home/builder/autotest-runner.jar ./
 COPY --from=cache /root/.m2 /root/.m2
 
 # Copy Maven pom.xml
-COPY --from=cache /opt/exercise/pom.xml /home/pom.xml
+COPY --from=cache /opt/exercise/pom.xml /root/pom.xml
 
 ENTRYPOINT ["sh", "/opt/test-runner/bin/run.sh"]

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -22,7 +22,7 @@ cp -R $input_folder/* .
 
 find . -mindepth 1 -type f | grep 'Test.java' | xargs -I file sed -i "s/@Ignore(.*)//g;s/@Ignore//g;" file
 
-cp /home/pom.xml .
+cp /root/pom.xml .
 
 java -jar /opt/test-runner/autotest-runner.jar $problem_slug
 mv results.json $output_folder

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -22,5 +22,7 @@ cp -R $input_folder/* .
 
 find . -mindepth 1 -type f | grep 'Test.java' | xargs -I file sed -i "s/@Ignore(.*)//g;s/@Ignore//g;" file
 
+cp /home/pom.xml .
+
 java -jar /opt/test-runner/autotest-runner.jar $problem_slug
 mv results.json $output_folder

--- a/exercise/pom.xml
+++ b/exercise/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.exercism</groupId>
+  <artifactId>exercise</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.15.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <configuration>
+            <source>11</source>
+            <target>11</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/exercise/pom.xml
+++ b/exercise/pom.xml
@@ -27,6 +27,16 @@
       <version>3.15.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency><!-- Used here: https://github.com/exercism/java/blob/acfdd2b654a1e2b8bb497c3af25a9e2eff1044e0/exercises/practice/rest-api/build.gradle#L14 -->
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20190722</version>
+    </dependency>
+    <dependency><!-- Used here: https://github.com/exercism/java/blob/acfdd2b654a1e2b8bb497c3af25a9e2eff1044e0/exercises/practice/hangman/build.gradle#L14 -->
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>2.2.12</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/lib/src/main/java/com/exercism/runner/TestRunner.java
+++ b/lib/src/main/java/com/exercism/runner/TestRunner.java
@@ -16,33 +16,36 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public final class TestRunner {
-    private static final String GRADLE_TEST_ERR = "gradle-test.err";
+    private static final String MAVEN_TEST_OUTPUT = "maven-test.out";
 
     public static void main(String[] args) throws InterruptedException, IOException {
         run(args[0]);
     }
 
     private static void run(String slug) throws InterruptedException, IOException {
-        Process gradleTest = new ProcessBuilder(
-            "gradle",
+        Process mavenTest = new ProcessBuilder(
+            "mvn",
             "test",
             "--offline",
-            "--no-daemon",
-            "--warning-mode=none")
-            .redirectError(new File(GRADLE_TEST_ERR))
+            "--legacy-local-repository",
+            "--batch-mode",
+            "--non-recursive",
+            "--quiet")
+            .redirectOutput(new File(MAVEN_TEST_OUTPUT))
             .start();
-        if (!gradleTest.waitFor(20, SECONDS)) {
-            throw new IllegalStateException("gradle test did not complete within 20 seconds");
+        if (!mavenTest.waitFor(20, SECONDS)) {
+            throw new IllegalStateException("test did not complete within 20 seconds");
         }
-        if (gradleTest.exitValue() != 0) {
-            String gradleErrorOutput = Files.asCharSource(
-                Paths.get(GRADLE_TEST_ERR).toFile(), StandardCharsets.UTF_8)
+
+        if (mavenTest.exitValue() != 0) {
+            String mavenOutput = Files.asCharSource(
+                Paths.get(MAVEN_TEST_OUTPUT).toFile(), StandardCharsets.UTF_8)
                 .read();
-            if (gradleErrorOutput.contains("compileJava")) {
+            if (mavenOutput.contains("ERROR")) {
                 ReportGenerator.report(
                     Report.builder()
                         .setStatus("error")
-                        .setMessage(gradleErrorOutput)
+                        .setMessage(mavenOutput)
                         .build());
                 return;
             }
@@ -56,7 +59,7 @@ public final class TestRunner {
         }
         ImmutableMap<String, String> testCodeByTestName = testParser.buildTestCodeMap();
         JUnitXmlParser xmlParser = new JUnitXmlParser(testCodeByTestName);
-        for (Path filePath : MoreFiles.listFiles(Paths.get("build", "test-results", "test"))) {
+        for (Path filePath : MoreFiles.listFiles(Paths.get("target", "surefire-reports"))) {
             if (MoreFiles.getFileExtension(filePath).equals("xml")) {
                 xmlParser.parse(filePath.toFile());
             }

--- a/lib/src/main/java/com/exercism/runner/TestRunner.java
+++ b/lib/src/main/java/com/exercism/runner/TestRunner.java
@@ -41,7 +41,7 @@ public final class TestRunner {
             String mavenOutput = Files.asCharSource(
                 Paths.get(MAVEN_TEST_OUTPUT).toFile(), StandardCharsets.UTF_8)
                 .read();
-            if (mavenOutput.contains("ERROR")) {
+            if (mavenOutput.contains("COMPILATION ERROR")) {
                 ReportGenerator.report(
                     Report.builder()
                         .setStatus("error")

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -13,7 +13,7 @@ OutputDirectory="$3"
 
 docker build -t exercism/java-test-runner .
 
-docker run \
+time docker run \
     --network none \
     --mount type=bind,src="${InputDirectory}",dst=/solution \
     --mount type=bind,src="${OutputDirectory}",dst=/results \

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -13,7 +13,7 @@ OutputDirectory="$3"
 
 docker build -t exercism/java-test-runner .
 
-time docker run \
+docker run \
     --network none \
     --mount type=bind,src="${InputDirectory}",dst=/solution \
     --mount type=bind,src="${OutputDirectory}",dst=/results \


### PR DESCRIPTION
Ref: https://github.com/exercism/java-test-runner/pull/37#issuecomment-966237668

The `maven` test task is taking consistently less than `gradle` on clean projects.

Again, please verify that I'm not missing something ( 😉  @ErikSchierboom ), but now I'm pretty confident this is the way to go, I tested on a few Java exercises and this is taking about 1/2 the time than `gradle`.

There are additional considerations to be done regarding error messages since if we take this approach ppl will see a Maven output instead of the Gradle one.
Moving all the Java track exercises to Maven can be considered and will be mostly mechanical work (cc. @iHiD ).