### PR TITLE
Make the XML Parser more defensive and parse errors

### DIFF
--- a/lib/src/main/java/com/exercism/runner/TestRunner.java
+++ b/lib/src/main/java/com/exercism/runner/TestRunner.java
@@ -58,7 +58,7 @@ public final class TestRunner {
             }
         }
         ImmutableMap<String, String> testCodeByTestName = testParser.buildTestCodeMap();
-        JUnitXmlParser xmlParser = new JUnitXmlParser(testCodeByTestName);
+        JUnitXmlParser xmlParser = new JUnitXmlParser(mavenTest.exitValue(), testCodeByTestName);
         for (Path filePath : MoreFiles.listFiles(Paths.get("target", "surefire-reports"))) {
             if (MoreFiles.getFileExtension(filePath).equals("xml")) {
                 xmlParser.parse(filePath.toFile());

--- a/lib/src/main/java/com/exercism/xml/data/Error.java
+++ b/lib/src/main/java/com/exercism/xml/data/Error.java
@@ -1,0 +1,23 @@
+package com.exercism.xml.data;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import com.google.common.base.MoreObjects;
+
+public class Error {
+    @JacksonXmlProperty(isAttribute = true)
+    public String message;
+    @JacksonXmlProperty(isAttribute = true)
+    public String type;
+    @JacksonXmlText
+    public String value;
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("message", message)
+            .add("type", type)
+            .add("value", value)
+            .toString(); 
+    }
+}

--- a/lib/src/main/java/com/exercism/xml/data/TestCase.java
+++ b/lib/src/main/java/com/exercism/xml/data/TestCase.java
@@ -11,6 +11,7 @@ public class TestCase {
     @JacksonXmlProperty(isAttribute = true)
     public double time;
     public Failure failure;
+    public Error error;
 
     @Override
     public String toString() {
@@ -19,6 +20,7 @@ public class TestCase {
             .add("classname", classname)
             .add("time", time)
             .add("failure", failure)
+            .add("error", error)
             .toString(); 
     }
 }


### PR DESCRIPTION
As reported in Slack, Maven is reporting runtime exceptions as Errors other than Failures, here we make the reporter much more defensive also.

I tested it manually, but automated tests can and should be implemented for this functionality.