### PR TITLE
Use 'full' exceptionFormat

### DIFF
--- a/exercise/build.gradle
+++ b/exercise/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-all-fail/build.gradle
+++ b/tests/example-all-fail/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-empty-file/build.gradle
+++ b/tests/example-empty-file/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-partial-fail/build.gradle
+++ b/tests/example-partial-fail/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-success-java17/build.gradle
+++ b/tests/example-success-java17/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-success/build.gradle
+++ b/tests/example-success/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-syntax-error/build.gradle
+++ b/tests/example-syntax-error/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'short'
+    exceptionFormat = 'full'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }


### PR DESCRIPTION
@SleeplessByte I sort of expected the test output to differ. Was there anything specific about https://github.com/exercism/java/issues/2121 that required the full exception format that we're not covering here?
