### PR TITLE
Revert "Use 'full' exceptionFormat"

### DIFF
--- a/exercise/build.gradle
+++ b/exercise/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-all-fail/build.gradle
+++ b/tests/example-all-fail/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-empty-file/build.gradle
+++ b/tests/example-empty-file/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-partial-fail/build.gradle
+++ b/tests/example-partial-fail/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-success-java17/build.gradle
+++ b/tests/example-success-java17/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-success/build.gradle
+++ b/tests/example-success/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }

--- a/tests/example-syntax-error/build.gradle
+++ b/tests/example-syntax-error/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
     showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }


### PR DESCRIPTION
Reverts exercism/java-test-runner#50

People started reporting problems in the test runner after this was merged, so let's revert it for now and investigate the problem further.