### PR TITLE
Use temurin focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mvn test dependency:go-offline -DexcludeReactor=false
 
 # === Build runtime image ===
 
-FROM maven:3.8-eclipse-temurin-17
+FROM maven:3.8.6-eclipse-temurin-17-focal
 WORKDIR /opt/test-runner
 
 # Copy binary and launcher script


### PR DESCRIPTION
Seems like the temurin base image updated the base ubuntu version under the hood and made this problem occur.

People are saying that keeping the temurin image on the focal version of ubuntu fixes this, so maybe we can try it too: 
 see https://github.com/flyway/flyway/issues/3457