### PR TITLE
Upgrade project-specific outdated libraries

### DIFF
--- a/exercise/build.gradle
+++ b/exercise/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {

--- a/exercise/pom.xml
+++ b/exercise/pom.xml
@@ -18,13 +18,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.15.0</version>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
     <dependency><!-- Used here: https://github.com/exercism/java/blob/acfdd2b654a1e2b8bb497c3af25a9e2eff1044e0/exercises/practice/rest-api/build.gradle#L14 -->

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,8 +20,8 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.5'
   implementation 'com.github.javaparser:javaparser-core:3.23.0'
-  implementation 'junit:junit:4.13'
-  implementation 'org.assertj:assertj-core:3.15.0'
+  implementation 'junit:junit:4.13.2'
+  implementation 'org.assertj:assertj-core:3.24.2'
 }
 
 tasks.named("shadowJar") {

--- a/tests/example-all-fail/build.gradle
+++ b/tests/example-all-fail/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {

--- a/tests/example-empty-file/build.gradle
+++ b/tests/example-empty-file/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {

--- a/tests/example-partial-fail/build.gradle
+++ b/tests/example-partial-fail/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {

--- a/tests/example-success-java17/build.gradle
+++ b/tests/example-success-java17/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {

--- a/tests/example-success/build.gradle
+++ b/tests/example-success/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {

--- a/tests/example-syntax-error/build.gradle
+++ b/tests/example-syntax-error/build.gradle
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-  testImplementation "junit:junit:4.13"
-  testImplementation "org.assertj:assertj-core:3.15.0"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.assertj:assertj-core:3.24.2"
 }
 
 test {


### PR DESCRIPTION
### Upgrade support libraries

Fixes vulnerabilities, also hides errors in IDE:

Upgrade junit lib 4.13 -> 4.13.2
Upgrade assertj-core 3.15 -> 3.24.2


## Dependencies 

- Main repo exercise's upgrade: exercism/java#2247
