### PR TITLE
Upgrade Gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # === Build builder image ===
 
-FROM gradle:7.3-jdk17 AS build
+FROM gradle:8.0.1-jdk17 AS build
 
 WORKDIR /home/builder
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.johnrengelman.shadow' version '6.1.0'
+  id 'com.github.johnrengelman.shadow' version '8.0.0'
   id 'java'
   id 'application'
   id 'eclipse'


### PR DESCRIPTION
# Docker build

- Use latest Gradle 8.0.1
- Upgrade Shadow plugin from 6.0.1 to 8.0.0 for latest Gradle support

Mentioned in https://github.com/exercism/java/pull/2247