### PR TITLE
Always use version 3 in output JSON

### DIFF
--- a/lib/src/main/java/com/exercism/report/Report.java
+++ b/lib/src/main/java/com/exercism/report/Report.java
@@ -25,7 +25,7 @@ public abstract class Report {
 	public abstract int version();
 
 	public static Builder builder() {
-	  return new AutoValue_Report.Builder().setVersion(2);
+	  return new AutoValue_Report.Builder().setVersion(3);
 	}
 
 	@AutoValue.Builder

--- a/lib/src/main/java/com/exercism/report/ReportGenerator.java
+++ b/lib/src/main/java/com/exercism/report/ReportGenerator.java
@@ -12,12 +12,10 @@ public class ReportGenerator {
     public static Report generate(Collection<TestDetails> testDetails, Map<TestSource, String> testCodeMap) {
         var reportDetails = testDetails.stream().map(item -> buildTestDetails(item, testCodeMap)).toList();
         var reportStatus = collapseStatuses(testDetails.stream().map(details -> details.result().status()).toList());
-        var reportVersion = testDetails.stream().anyMatch(details -> details.metadata().taskId().isPresent()) ? 3 : 2;
 
         return Report.builder()
                 .setTests(reportDetails)
                 .setStatus(mapStatus(reportStatus))
-                .setVersion(reportVersion)
                 .build();
     }
 

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -46,5 +46,5 @@
     "status" : "fail",
     "message" : "Message: null\nException: java.lang.AssertionError\n\tat org.junit.Assert.fail(Assert.java:87)\n\tat org.junit.Assert.assertTrue(Assert.java:42)\n\tat org.junit.Assert.assertTrue(Assert.java:53)\n\tat LeapTest.testYearDivBy4And5InLeapYear(LeapTest.java:37)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:568)\n"
   } ],
-  "version" : 2
+  "version" : 3
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -2,5 +2,5 @@
   "status" : "error",
   "message" : "./src/test/java/LeapTest.java:10: error: cannot find symbol\n    private Leap leap;\n            ^\n  symbol:   class Leap\n  location: class LeapTest./src/test/java/LeapTest.java:14: error: cannot find symbol\n        leap = new Leap();\n                   ^\n  symbol:   class Leap\n  location: class LeapTest",
   "tests" : [ ],
-  "version" : 2
+  "version" : 3
 }

--- a/tests/example-junit5/expected_results.json
+++ b/tests/example-junit5/expected_results.json
@@ -39,5 +39,5 @@
     "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
     "status" : "pass"
   } ],
-  "version" : 2
+  "version" : 3
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -39,5 +39,5 @@
     "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertTrue(leap.isLeapYear(1960));\n}",
     "status" : "pass"
   } ],
-  "version" : 2
+  "version" : 3
 }

--- a/tests/example-success-java17/expected_results.json
+++ b/tests/example-success-java17/expected_results.json
@@ -37,5 +37,5 @@
     "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertTrue(leap.isLeapYear(1960));\n}",
     "status" : "pass"
   } ],
-  "version" : 2
+  "version" : 3
 }

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -37,5 +37,5 @@
     "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertTrue(leap.isLeapYear(1960));\n}",
     "status" : "pass"
   } ],
-  "version" : 2
+  "version" : 3
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -2,5 +2,5 @@
   "status" : "error",
   "message" : "./src/main/java/Leap.java:1: error: class, interface, enum, or record expected\nclassYY Leapy {@\n^./src/main/java/Leap.java:1: error: reached end of file while parsing\nclassYY Leapy {@\n                ^./src/main/java/Leap.java:2: error: reached end of file while parsing\n",
   "tests" : [ ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
Conditionally setting the version to 3 doesn't really make sense here. The test runner results follow the v3 spec, even if the `test_id` property is missing (which is controlled by the exercises, not the test runner).