### PR TITLE
Never use status "error" when tests have been run

### DIFF
--- a/lib/src/main/java/com/exercism/report/ReportGenerator.java
+++ b/lib/src/main/java/com/exercism/report/ReportGenerator.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class ReportGenerator {
     public static Report generate(Collection<TestDetails> testDetails, Map<TestSource, String> testCodeMap) {
         var reportDetails = testDetails.stream().map(item -> buildTestDetails(item, testCodeMap)).toList();
-        var reportStatus = collapseStatuses(testDetails.stream().map(details -> details.result().status()).toList());
+        var reportStatus = collapseStatuses(testDetails);
 
         return Report.builder()
                 .setTests(reportDetails)
@@ -44,17 +44,7 @@ public class ReportGenerator {
         };
     }
 
-    private static TestStatus collapseStatuses(Collection<TestStatus> statuses) {
-        for (TestStatus status : statuses) {
-            if (status == TestStatus.ERROR) {
-                return TestStatus.ERROR;
-            }
-
-            if (status == TestStatus.FAIL) {
-                return TestStatus.FAIL;
-            }
-        }
-
-        return TestStatus.PASS;
+    private static TestStatus collapseStatuses(Collection<TestDetails> testDetails) {
+        return testDetails.stream().allMatch(details -> details.result().status() == TestStatus.PASS) ? TestStatus.PASS : TestStatus.FAIL;
     }
 }


### PR DESCRIPTION
After reading [this forum topic](https://forum.exercism.org/t/test-runner-update-in-docker-results-interpretation-by-ui/7344) I realized that the Java test runner incorrectly uses the status `error` when any test case has errored. This is not in line with the spec, which basically says that it should only be used if there was a global error running the tests.

So with this update, any test case having a status `error` will result in a overall status `fail`.