### PR TITLE
Ensure test result order matches order of test methods

### DIFF
--- a/src/main/java/com/exercism/junit/JUnitTestParser.java
+++ b/src/main/java/com/exercism/junit/JUnitTestParser.java
@@ -6,14 +6,15 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.google.common.collect.ImmutableMap;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public final class JUnitTestParser {
-    private final ImmutableMap.Builder<TestSource, String> testCodeByTestName = ImmutableMap.builder();
+    private final Map<TestSource, String> testCodeByTestName = new LinkedHashMap<>();
 
     public void parse(File file) {
         try {
@@ -53,7 +54,7 @@ public final class JUnitTestParser {
         return String.join("$", classNames.reversed());
     }
 
-    public ImmutableMap<TestSource, String> buildTestCodeMap() {
-        return testCodeByTestName.build();
+    public Map<TestSource, String> buildTestCodeMap() {
+        return new LinkedHashMap<>(testCodeByTestName);
     }
 }

--- a/src/main/java/com/exercism/report/ReportGenerator.java
+++ b/src/main/java/com/exercism/report/ReportGenerator.java
@@ -5,13 +5,20 @@ import com.exercism.TestSource;
 import com.exercism.TestStatus;
 import com.google.common.base.Throwables;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
 public class ReportGenerator {
     public static Report generate(Collection<TestDetails> testDetails, Map<TestSource, String> testCodeMap) {
-        var reportDetails = testDetails.stream().map(item -> buildTestDetails(item, testCodeMap)).toList();
         var reportStatus = collapseStatuses(testDetails);
+        var reportDetails = new ArrayList<com.exercism.report.TestDetails>();
+
+        for (var entry : testCodeMap.entrySet()) {
+            testDetails.stream()
+                    .filter(item -> item.source().equals(entry.getKey()))
+                    .forEach(item -> reportDetails.add(buildTestDetails(item, entry.getValue())));
+        }
 
         return Report.builder()
                 .setTests(reportDetails)
@@ -19,10 +26,10 @@ public class ReportGenerator {
                 .build();
     }
 
-    private static com.exercism.report.TestDetails buildTestDetails(TestDetails testDetails, Map<TestSource, String> testCodeMap) {
+    private static com.exercism.report.TestDetails buildTestDetails(TestDetails testDetails, String testCode) {
         var detailBuilder = com.exercism.report.TestDetails.builder()
                 .setStatus(mapStatus(testDetails.result().status()))
-                .setTestCode(testCodeMap.get(testDetails.source()))
+                .setTestCode(testCode)
                 .setName(testDetails.metadata().name())
                 .setOutput(testDetails.output());
 

--- a/tests/solution-passes-all-tests/expected_results.json
+++ b/tests/solution-passes-all-tests/expected_results.json
@@ -1,40 +1,40 @@
 {
   "status" : "pass",
   "tests" : [ {
-    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "name" : "testYearNotDivBy4InCommonYear()",
+    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy2NotDivBy4InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy2NotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(1970)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy400InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testYearNotDivBy4InCommonYear()",
-    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
-    "status" : "pass"
-  }, {
     "name" : "testYearDivBy4NotDivBy100InLeapYear()",
     "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "name" : "testYearDivBy4And5InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy100NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy100NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(2100)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy200NotDivBy400InCommonYear()",
-    "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
+    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy4And5InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
+    "name" : "testYearDivBy400InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy200NotDivBy400InCommonYear()",
+    "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
     "status" : "pass"
   } ],
   "version" : 3

--- a/tests/solution-passes-no-tests/expected_results.json
+++ b/tests/solution-passes-no-tests/expected_results.json
@@ -1,50 +1,50 @@
 {
   "status" : "fail",
   "tests" : [ {
-    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "name" : "testYearNotDivBy4InCommonYear()",
+    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
     "status" : "fail",
-    "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy100NotDivBy3IsNotLeapYear(LeapTest.java:49)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
+    "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearNotDivBy4InCommonYear(LeapTest.java:19)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
     "name" : "testYearDivBy2NotDivBy4InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy2NotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(1970)).isFalse();\n}",
     "status" : "fail",
     "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy2NotDivBy4InCommonYear(LeapTest.java:25)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
-    "name" : "testYearDivBy400InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
-    "status" : "fail",
-    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy400InLeapYear(LeapTest.java:55)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
-  }, {
-    "name" : "testYearNotDivBy4InCommonYear()",
-    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
-    "status" : "fail",
-    "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearNotDivBy4InCommonYear(LeapTest.java:19)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
-  }, {
     "name" : "testYearDivBy4NotDivBy100InLeapYear()",
     "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
     "status" : "fail",
     "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy4NotDivBy100InLeapYear(LeapTest.java:31)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
-    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "name" : "testYearDivBy4And5InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
     "status" : "fail",
-    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy400NotDivBy125IsLeapYear(LeapTest.java:61)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
+    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy4And5InLeapYear(LeapTest.java:37)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
     "name" : "testYearDivBy100NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy100NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(2100)).isFalse();\n}",
     "status" : "fail",
     "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy100NotDivBy400InCommonYear(LeapTest.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
+    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "status" : "fail",
+    "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy100NotDivBy3IsNotLeapYear(LeapTest.java:49)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
+  }, {
+    "name" : "testYearDivBy400InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
+    "status" : "fail",
+    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy400InLeapYear(LeapTest.java:55)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
+  }, {
+    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "status" : "fail",
+    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy400NotDivBy125IsLeapYear(LeapTest.java:61)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
+  }, {
     "name" : "testYearDivBy200NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
     "status" : "fail",
     "message" : "Message: \nExpecting value to be false but was true\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be false but was true\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy200NotDivBy400InCommonYear(LeapTest.java:67)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
-  }, {
-    "name" : "testYearDivBy4And5InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
-    "status" : "fail",
-    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy4And5InLeapYear(LeapTest.java:37)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   } ],
   "version" : 3
 }

--- a/tests/solution-passes-some-tests/expected_results.json
+++ b/tests/solution-passes-some-tests/expected_results.json
@@ -1,12 +1,28 @@
 {
   "status" : "fail",
   "tests" : [ {
-    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "name" : "testYearNotDivBy4InCommonYear()",
+    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy2NotDivBy4InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy2NotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(1970)).isFalse();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy4NotDivBy100InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy4And5InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy100NotDivBy400InCommonYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(2100)).isFalse();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy400InLeapYear()",
@@ -14,29 +30,13 @@
     "status" : "fail",
     "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy400InLeapYear(LeapTest.java:55)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
-    "name" : "testYearNotDivBy4InCommonYear()",
-    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testYearDivBy4NotDivBy100InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
-    "status" : "pass"
-  }, {
     "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
     "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
     "status" : "fail",
     "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest.testYearDivBy400NotDivBy125IsLeapYear(LeapTest.java:61)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   }, {
-    "name" : "testYearDivBy100NotDivBy400InCommonYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(2100)).isFalse();\n}",
-    "status" : "pass"
-  }, {
     "name" : "testYearDivBy200NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testYearDivBy4And5InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
     "status" : "pass"
   } ],
   "version" : 3

--- a/tests/solution-uses-java17/expected_results.json
+++ b/tests/solution-uses-java17/expected_results.json
@@ -1,40 +1,40 @@
 {
   "status" : "pass",
   "tests" : [ {
-    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "name" : "testYearNotDivBy4InCommonYear()",
+    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy2NotDivBy4InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy2NotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(1970)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy400InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testYearNotDivBy4InCommonYear()",
-    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
-    "status" : "pass"
-  }, {
     "name" : "testYearDivBy4NotDivBy100InLeapYear()",
     "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "name" : "testYearDivBy4And5InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy100NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy100NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(2100)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy200NotDivBy400InCommonYear()",
-    "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
+    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearDivBy4And5InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
+    "name" : "testYearDivBy400InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy200NotDivBy400InCommonYear()",
+    "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
     "status" : "pass"
   } ],
   "version" : 3

--- a/tests/solution-uses-java21/expected_results.json
+++ b/tests/solution-uses-java21/expected_results.json
@@ -1,24 +1,24 @@
 {
   "status" : "pass",
   "tests" : [ {
-    "name" : "testExample()",
-    "test_code" : "@Test\npublic void testExample() {\n    DoublyLinkedList<String> list = new DoublyLinkedList<>();\n    list.push(\"ten\");\n    list.push(\"twenty\");\n    assertThat(list.pop()).isEqualTo(\"twenty\");\n    list.push(\"thirty\");\n    assertThat(list.shift()).isEqualTo(\"ten\");\n    list.unshift(\"forty\");\n    list.push(\"fifty\");\n    assertThat(list.shift()).isEqualTo(\"forty\");\n    assertThat(list.pop()).isEqualTo(\"fifty\");\n    assertThat(list.shift()).isEqualTo(\"thirty\");\n}",
+    "name" : "testPushPop()",
+    "test_code" : "@Test\npublic void testPushPop() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.push(10);\n    list.push(20);\n    list.push(30);\n    assertThat(list.pop()).isEqualTo(30);\n    assertThat(list.pop()).isEqualTo(20);\n    assertThat(list.pop()).isEqualTo(10);\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testPushOncePopTwice()",
+    "test_code" : "@Test\npublic void testPushOncePopTwice() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.push(10);\n    assertThat(list.pop()).isEqualTo(10);\n    assertThat(list.pop()).isNull();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testPushShift()",
+    "test_code" : "@Test\npublic void testPushShift() {\n    DoublyLinkedList<String> list = new DoublyLinkedList<>();\n    list.push(\"10\");\n    list.push(\"20\");\n    list.push(\"30\");\n    assertThat(list.shift()).isEqualTo(\"10\");\n    assertThat(list.shift()).isEqualTo(\"20\");\n    assertThat(list.shift()).isEqualTo(\"30\");\n}",
     "status" : "pass"
   }, {
     "name" : "testPushPopShift()",
     "test_code" : "@Test\npublic void testPushPopShift() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.push(10);\n    assertThat(list.pop()).isEqualTo(10);\n    assertThat(list.shift()).isNull();\n}",
     "status" : "pass"
   }, {
-    "name" : "testUnshiftShiftPop()",
-    "test_code" : "@Test\npublic void testUnshiftShiftPop() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.unshift(10);\n    assertThat(list.shift()).isEqualTo(10);\n    assertThat(list.pop()).isNull();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testPushPop()",
-    "test_code" : "@Test\npublic void testPushPop() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.push(10);\n    list.push(20);\n    list.push(30);\n    assertThat(list.pop()).isEqualTo(30);\n    assertThat(list.pop()).isEqualTo(20);\n    assertThat(list.pop()).isEqualTo(10);\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testPushShift()",
-    "test_code" : "@Test\npublic void testPushShift() {\n    DoublyLinkedList<String> list = new DoublyLinkedList<>();\n    list.push(\"10\");\n    list.push(\"20\");\n    list.push(\"30\");\n    assertThat(list.shift()).isEqualTo(\"10\");\n    assertThat(list.shift()).isEqualTo(\"20\");\n    assertThat(list.shift()).isEqualTo(\"30\");\n}",
+    "name" : "testUnshiftShift()",
+    "test_code" : "@Test\npublic void testUnshiftShift() {\n    DoublyLinkedList<Character> list = new DoublyLinkedList<>();\n    list.unshift('1');\n    list.unshift('2');\n    list.unshift('3');\n    assertThat(list.shift()).isEqualTo('3');\n    assertThat(list.shift()).isEqualTo('2');\n    assertThat(list.shift()).isEqualTo('1');\n}",
     "status" : "pass"
   }, {
     "name" : "testUnshiftOnceShiftTwice()",
@@ -29,12 +29,12 @@
     "test_code" : "@Test\npublic void testUnshiftPop() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.unshift(10);\n    list.unshift(20);\n    list.unshift(30);\n    assertThat(list.pop()).isEqualTo(10);\n    assertThat(list.pop()).isEqualTo(20);\n    assertThat(list.pop()).isEqualTo(30);\n}",
     "status" : "pass"
   }, {
-    "name" : "testUnshiftShift()",
-    "test_code" : "@Test\npublic void testUnshiftShift() {\n    DoublyLinkedList<Character> list = new DoublyLinkedList<>();\n    list.unshift('1');\n    list.unshift('2');\n    list.unshift('3');\n    assertThat(list.shift()).isEqualTo('3');\n    assertThat(list.shift()).isEqualTo('2');\n    assertThat(list.shift()).isEqualTo('1');\n}",
+    "name" : "testUnshiftShiftPop()",
+    "test_code" : "@Test\npublic void testUnshiftShiftPop() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.unshift(10);\n    assertThat(list.shift()).isEqualTo(10);\n    assertThat(list.pop()).isNull();\n}",
     "status" : "pass"
   }, {
-    "name" : "testPushOncePopTwice()",
-    "test_code" : "@Test\npublic void testPushOncePopTwice() {\n    DoublyLinkedList<Integer> list = new DoublyLinkedList<>();\n    list.push(10);\n    assertThat(list.pop()).isEqualTo(10);\n    assertThat(list.pop()).isNull();\n}",
+    "name" : "testExample()",
+    "test_code" : "@Test\npublic void testExample() {\n    DoublyLinkedList<String> list = new DoublyLinkedList<>();\n    list.push(\"ten\");\n    list.push(\"twenty\");\n    assertThat(list.pop()).isEqualTo(\"twenty\");\n    list.push(\"thirty\");\n    assertThat(list.shift()).isEqualTo(\"ten\");\n    list.unshift(\"forty\");\n    list.push(\"fifty\");\n    assertThat(list.shift()).isEqualTo(\"forty\");\n    assertThat(list.pop()).isEqualTo(\"fifty\");\n    assertThat(list.shift()).isEqualTo(\"thirty\");\n}",
     "status" : "pass"
   } ],
   "version" : 3

--- a/tests/solution-writes-to-console/expected_results.json
+++ b/tests/solution-writes-to-console/expected_results.json
@@ -1,8 +1,8 @@
 {
   "status" : "pass",
   "tests" : [ {
-    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "name" : "testYearNotDivBy4InCommonYear()",
+    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
     "status" : "pass",
     "output" : "Printing to stdout\n"
   }, {
@@ -11,23 +11,13 @@
     "status" : "pass",
     "output" : "Printing to stdout\n"
   }, {
-    "name" : "testYearDivBy400InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
-    "status" : "pass",
-    "output" : "Printing to stdout\n"
-  }, {
-    "name" : "testYearNotDivBy4InCommonYear()",
-    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
-    "status" : "pass",
-    "output" : "Printing to stdout\n"
-  }, {
     "name" : "testYearDivBy4NotDivBy100InLeapYear()",
     "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
     "status" : "pass",
     "output" : "Printing to stdout\n"
   }, {
-    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "name" : "testYearDivBy4And5InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
     "status" : "pass",
     "output" : "Printing to stdout\n"
   }, {
@@ -36,13 +26,23 @@
     "status" : "pass",
     "output" : "Printing to stdout\n"
   }, {
-    "name" : "testYearDivBy200NotDivBy400InCommonYear()",
-    "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
+    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
     "status" : "pass",
     "output" : "Printing to stdout\n"
   }, {
-    "name" : "testYearDivBy4And5InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
+    "name" : "testYearDivBy400InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
+    "status" : "pass",
+    "output" : "Printing to stdout\n"
+  }, {
+    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "status" : "pass",
+    "output" : "Printing to stdout\n"
+  }, {
+    "name" : "testYearDivBy200NotDivBy400InCommonYear()",
+    "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
     "status" : "pass",
     "output" : "Printing to stdout\n"
   } ],

--- a/tests/tests-with-nested-classes/expected_results.json
+++ b/tests/tests-with-nested-classes/expected_results.json
@@ -1,43 +1,43 @@
 {
   "status" : "fail",
   "tests" : [ {
-    "name" : "testYearDivBy400InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
-    "status" : "fail",
-    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest$LeapYearsTest.testYearDivBy400InLeapYear(LeapTest.java:66)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
-  }, {
-    "name" : "testYearDivBy4NotDivBy100InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
-    "status" : "fail",
-    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest$LeapYearsTest.testYearDivBy400NotDivBy125IsLeapYear(LeapTest.java:72)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
-  }, {
-    "name" : "testYearDivBy4And5InLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
-    "status" : "pass"
-  }, {
-    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
-    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
+    "name" : "testYearNotDivBy4InCommonYear()",
+    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy2NotDivBy4InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy2NotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(1970)).isFalse();\n}",
     "status" : "pass"
   }, {
-    "name" : "testYearNotDivBy4InCommonYear()",
-    "test_code" : "@Test\npublic void testYearNotDivBy4InCommonYear() {\n    assertThat(leap.isLeapYear(2015)).isFalse();\n}",
-    "status" : "pass"
-  }, {
     "name" : "testYearDivBy100NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy100NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(2100)).isFalse();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy100NotDivBy3IsNotLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy100NotDivBy3IsNotLeapYear() {\n    assertThat(leap.isLeapYear(1900)).isFalse();\n}",
     "status" : "pass"
   }, {
     "name" : "testYearDivBy200NotDivBy400InCommonYear()",
     "test_code" : "@Test\npublic void testYearDivBy200NotDivBy400InCommonYear() {\n    assertThat(leap.isLeapYear(1800)).isFalse();\n}",
     "status" : "pass"
+  }, {
+    "name" : "testYearDivBy4NotDivBy100InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4NotDivBy100InLeapYear() {\n    assertThat(leap.isLeapYear(1996)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy4And5InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy4And5InLeapYear() {\n    assertThat(leap.isLeapYear(1960)).isTrue();\n}",
+    "status" : "pass"
+  }, {
+    "name" : "testYearDivBy400InLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400InLeapYear() {\n    assertThat(leap.isLeapYear(2000)).isTrue();\n}",
+    "status" : "fail",
+    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest$LeapYearsTest.testYearDivBy400InLeapYear(LeapTest.java:66)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
+  }, {
+    "name" : "testYearDivBy400NotDivBy125IsLeapYear()",
+    "test_code" : "@Test\npublic void testYearDivBy400NotDivBy125IsLeapYear() {\n    assertThat(leap.isLeapYear(2400)).isTrue();\n}",
+    "status" : "fail",
+    "message" : "Message: \nExpecting value to be true but was false\nException: org.opentest4j.AssertionFailedError: \nExpecting value to be true but was false\n\tat java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)\n\tat java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)\n\tat LeapTest$LeapYearsTest.testYearDivBy400NotDivBy125IsLeapYear(LeapTest.java:72)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:580)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n\tat java.base/java.util.ArrayList.forEach(ArrayList.java:1596)\n"
   } ],
   "version" : 3
 }

--- a/tests/tests-with-task-ids-and-display-names/expected_results.json
+++ b/tests/tests-with-task-ids-and-display-names/expected_results.json
@@ -1,8 +1,43 @@
 {
   "status" : "pass",
   "tests" : [ {
-    "name" : "totalTimeInMinutes method calculates the correct value for multiple layers",
-    "test_code" : "@Test\n@Tag(\"task:4\")\n@DisplayName(\"totalTimeInMinutes method calculates the correct value for multiple layers\")\npublic void total_time_in_minutes_for_multiple_layers() {\n    assertThat(new Lasagna().totalTimeInMinutes(4, 8)).isEqualTo(16);\n}",
+    "name" : "Implemented the expectedMinutesInOven method",
+    "test_code" : "@Test\n@Tag(\"task:1\")\n@DisplayName(\"Implemented the expectedMinutesInOven method\")\npublic void implemented_expected_minutes_in_oven() {\n    assertThat(new Lasagna().hasMethod(\"expectedMinutesInOven\")).withFailMessage(\"Method expectedMinutesInOven must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"expectedMinutesInOven\")).withFailMessage(\"Method expectedMinutesInOven must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"expectedMinutesInOven\")).withFailMessage(\"Method expectedMinutesInOven must return an int\").isTrue();\n}",
+    "status" : "pass",
+    "task_id" : 1
+  }, {
+    "name" : "expectedMinutesInOven method returns the correct value",
+    "test_code" : "@Test\n@Tag(\"task:1\")\n@DisplayName(\"expectedMinutesInOven method returns the correct value\")\npublic void expected_minutes_in_oven() {\n    assertThat(new Lasagna().expectedMinutesInOven()).isEqualTo(40);\n}",
+    "status" : "pass",
+    "task_id" : 1
+  }, {
+    "name" : "Implemented the remainingMinutesInOven method",
+    "test_code" : "@Test\n@Tag(\"task:2\")\n@DisplayName(\"Implemented the remainingMinutesInOven method\")\npublic void implemented_remaining_minutes_in_oven() {\n    assertThat(new Lasagna().hasMethod(\"remainingMinutesInOven\", int.class)).withFailMessage(\"Method remainingMinutesInOven must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"remainingMinutesInOven\", int.class)).withFailMessage(\"Method remainingMinutesInOven must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"remainingMinutesInOven\", int.class)).withFailMessage(\"Method remainingMinutesInOven must return an int\").isTrue();\n}",
+    "status" : "pass",
+    "task_id" : 2
+  }, {
+    "name" : "remainingMinutesInOven method calculates and returns the correct value",
+    "test_code" : "@Test\n@Tag(\"task:2\")\n@DisplayName(\"remainingMinutesInOven method calculates and returns the correct value\")\npublic void remaining_minutes_in_oven() {\n    assertThat(new Lasagna().remainingMinutesInOven(25)).isEqualTo(15);\n}",
+    "status" : "pass",
+    "task_id" : 2
+  }, {
+    "name" : "Implemented the preparationTimeInMinutes method",
+    "test_code" : "@Test\n@Tag(\"task:3\")\n@DisplayName(\"Implemented the preparationTimeInMinutes method\")\npublic void implemented_preparation_time_in_minutes() {\n    assertThat(new Lasagna().hasMethod(\"preparationTimeInMinutes\", int.class)).withFailMessage(\"Method preparationTimeInMinutes must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"preparationTimeInMinutes\", int.class)).withFailMessage(\"Method preparationTimeInMinutes must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"preparationTimeInMinutes\", int.class)).withFailMessage(\"Method preparationTimeInMinutes must return an int\").isTrue();\n}",
+    "status" : "pass",
+    "task_id" : 3
+  }, {
+    "name" : "preparationTimeInMinutes method calculates the correct value for single layer",
+    "test_code" : "@Test\n@Tag(\"task:3\")\n@DisplayName(\"preparationTimeInMinutes method calculates the correct value for single layer\")\npublic void preparation_time_in_minutes_for_one_layer() {\n    assertThat(new Lasagna().preparationTimeInMinutes(1)).isEqualTo(2);\n}",
+    "status" : "pass",
+    "task_id" : 3
+  }, {
+    "name" : "preparationTimeInMinutes method calculates the correct value for multiple layers",
+    "test_code" : "@Test\n@Tag(\"task:3\")\n@DisplayName(\"preparationTimeInMinutes method calculates the correct value for multiple layers\")\npublic void preparation_time_in_minutes_for_multiple_layers() {\n    assertThat(new Lasagna().preparationTimeInMinutes(4)).isEqualTo(8);\n}",
+    "status" : "pass",
+    "task_id" : 3
+  }, {
+    "name" : "Implemented the totalTimeInMinutes method",
+    "test_code" : "@Test\n@Tag(\"task:4\")\n@DisplayName(\"Implemented the totalTimeInMinutes method\")\npublic void implemented_total_time_in_minutes() {\n    assertThat(new Lasagna().hasMethod(\"totalTimeInMinutes\", int.class, int.class)).withFailMessage(\"Method totalTimeInMinutes must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"totalTimeInMinutes\", int.class, int.class)).withFailMessage(\"Method totalTimeInMinutes must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"totalTimeInMinutes\", int.class, int.class)).withFailMessage(\"Method totalTimeInMinutes must return an int\").isTrue();\n}",
     "status" : "pass",
     "task_id" : 4
   }, {
@@ -11,45 +46,10 @@
     "status" : "pass",
     "task_id" : 4
   }, {
-    "name" : "remainingMinutesInOven method calculates and returns the correct value",
-    "test_code" : "@Test\n@Tag(\"task:2\")\n@DisplayName(\"remainingMinutesInOven method calculates and returns the correct value\")\npublic void remaining_minutes_in_oven() {\n    assertThat(new Lasagna().remainingMinutesInOven(25)).isEqualTo(15);\n}",
-    "status" : "pass",
-    "task_id" : 2
-  }, {
-    "name" : "preparationTimeInMinutes method calculates the correct value for single layer",
-    "test_code" : "@Test\n@Tag(\"task:3\")\n@DisplayName(\"preparationTimeInMinutes method calculates the correct value for single layer\")\npublic void preparation_time_in_minutes_for_one_layer() {\n    assertThat(new Lasagna().preparationTimeInMinutes(1)).isEqualTo(2);\n}",
-    "status" : "pass",
-    "task_id" : 3
-  }, {
-    "name" : "expectedMinutesInOven method returns the correct value",
-    "test_code" : "@Test\n@Tag(\"task:1\")\n@DisplayName(\"expectedMinutesInOven method returns the correct value\")\npublic void expected_minutes_in_oven() {\n    assertThat(new Lasagna().expectedMinutesInOven()).isEqualTo(40);\n}",
-    "status" : "pass",
-    "task_id" : 1
-  }, {
-    "name" : "Implemented the totalTimeInMinutes method",
-    "test_code" : "@Test\n@Tag(\"task:4\")\n@DisplayName(\"Implemented the totalTimeInMinutes method\")\npublic void implemented_total_time_in_minutes() {\n    assertThat(new Lasagna().hasMethod(\"totalTimeInMinutes\", int.class, int.class)).withFailMessage(\"Method totalTimeInMinutes must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"totalTimeInMinutes\", int.class, int.class)).withFailMessage(\"Method totalTimeInMinutes must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"totalTimeInMinutes\", int.class, int.class)).withFailMessage(\"Method totalTimeInMinutes must return an int\").isTrue();\n}",
+    "name" : "totalTimeInMinutes method calculates the correct value for multiple layers",
+    "test_code" : "@Test\n@Tag(\"task:4\")\n@DisplayName(\"totalTimeInMinutes method calculates the correct value for multiple layers\")\npublic void total_time_in_minutes_for_multiple_layers() {\n    assertThat(new Lasagna().totalTimeInMinutes(4, 8)).isEqualTo(16);\n}",
     "status" : "pass",
     "task_id" : 4
-  }, {
-    "name" : "Implemented the remainingMinutesInOven method",
-    "test_code" : "@Test\n@Tag(\"task:2\")\n@DisplayName(\"Implemented the remainingMinutesInOven method\")\npublic void implemented_remaining_minutes_in_oven() {\n    assertThat(new Lasagna().hasMethod(\"remainingMinutesInOven\", int.class)).withFailMessage(\"Method remainingMinutesInOven must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"remainingMinutesInOven\", int.class)).withFailMessage(\"Method remainingMinutesInOven must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"remainingMinutesInOven\", int.class)).withFailMessage(\"Method remainingMinutesInOven must return an int\").isTrue();\n}",
-    "status" : "pass",
-    "task_id" : 2
-  }, {
-    "name" : "preparationTimeInMinutes method calculates the correct value for multiple layers",
-    "test_code" : "@Test\n@Tag(\"task:3\")\n@DisplayName(\"preparationTimeInMinutes method calculates the correct value for multiple layers\")\npublic void preparation_time_in_minutes_for_multiple_layers() {\n    assertThat(new Lasagna().preparationTimeInMinutes(4)).isEqualTo(8);\n}",
-    "status" : "pass",
-    "task_id" : 3
-  }, {
-    "name" : "Implemented the expectedMinutesInOven method",
-    "test_code" : "@Test\n@Tag(\"task:1\")\n@DisplayName(\"Implemented the expectedMinutesInOven method\")\npublic void implemented_expected_minutes_in_oven() {\n    assertThat(new Lasagna().hasMethod(\"expectedMinutesInOven\")).withFailMessage(\"Method expectedMinutesInOven must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"expectedMinutesInOven\")).withFailMessage(\"Method expectedMinutesInOven must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"expectedMinutesInOven\")).withFailMessage(\"Method expectedMinutesInOven must return an int\").isTrue();\n}",
-    "status" : "pass",
-    "task_id" : 1
-  }, {
-    "name" : "Implemented the preparationTimeInMinutes method",
-    "test_code" : "@Test\n@Tag(\"task:3\")\n@DisplayName(\"Implemented the preparationTimeInMinutes method\")\npublic void implemented_preparation_time_in_minutes() {\n    assertThat(new Lasagna().hasMethod(\"preparationTimeInMinutes\", int.class)).withFailMessage(\"Method preparationTimeInMinutes must be created\").isTrue();\n    assertThat(new Lasagna().isMethodPublic(\"preparationTimeInMinutes\", int.class)).withFailMessage(\"Method preparationTimeInMinutes must be public\").isTrue();\n    assertThat(new Lasagna().isMethodReturnType(int.class, \"preparationTimeInMinutes\", int.class)).withFailMessage(\"Method preparationTimeInMinutes must return an int\").isTrue();\n}",
-    "status" : "pass",
-    "task_id" : 3
   } ],
   "version" : 3
 }


### PR DESCRIPTION
This slightly changes the output of the test runner so that the order of the results matches the way the test methods are ordered in the exercise. This fixes #70.