### PR TITLE
Revert "Bump eclipse-temurin from 21 to 25"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY --chown=gradle:gradle . /app
 RUN gradle -i --stacktrace clean build
 
-FROM eclipse-temurin:25
+FROM eclipse-temurin:21
 
 WORKDIR /opt/test-runner
 COPY bin/run.sh bin/run.sh


### PR DESCRIPTION
Reverts exercism/java-test-runner#164

The upgrade to Java 25 caused Gradle builds to fail, so we’re staying on Java 21 for now.