### PR TITLE
Fix deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,17 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '9.2.2'
     id 'java'
     id 'application'
 }
 
 group = "org.exercism"
 version = "1.0-SNAPSHOT"
-mainClassName = 'com.exercism.TestRunner'
+
+tasks.jar {
+    manifest {
+        attributes["Main-Class"] = "com.exercism.TestRunner"
+    }
+}
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/exercism/report/ReportWriter.java
+++ b/src/main/java/com/exercism/report/ReportWriter.java
@@ -17,7 +17,7 @@ public class ReportWriter {
 	public void report(Report report) {
 		var mapper = new ObjectMapper();
 		mapper.registerModule(new Jdk8Module());
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+		mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
 		var filePath = this.outputDirectory.resolve("results.json");
 
 		try {


### PR DESCRIPTION
Fixes the following deprecation warnings from the builds and CI:

  Note: /app/src/main/java/com/exercism/report/ReportWriter.java uses or overrides a deprecated API.
  Note: Recompile with -Xlint:deprecation for details.

And:

  Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

(See [CI job](https://github.com/exercism/java-test-runner/actions/runs/18169507541/job/51720408494))