### PR TITLE
Fix Gradle deprecated warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,11 @@ dependencies {
     runtimeOnly 'io.reactivex.rxjava2:rxjava:2.2.12' // used in practice:hangman
 }
 
-shadowJar {
+def testRunnerJar = shadowJar {
     mergeServiceFiles()
     archiveFileName.set("java-test-runner.jar")
 }
 
-artifacts {
-    archives shadowJar
+tasks.named("assemble") {
+    dependsOn(testRunnerJar)
 }


### PR DESCRIPTION
This fixes the following Gradle warning:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.1.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
```

The exact error causing this:

```
> Configure project :
Build file '/home/kah/workspace/exercism-java-test-runner/build.gradle': line 50
The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/9.3.1/userguide/upgrading_version_9.html#sec:archives-configuration
        at build_4x7a0ltavkudv4dkogrktpgwk$_run_closure5.doCall$original(/home/kah/workspace/exercism-java-test-runner/build.gradle:50)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

[Incubating] Problems report is available at: file:///home/kah/workspace/exercism-java-test-runner/build/reports/problems/problems-report.html
```